### PR TITLE
GH-11 Render healthBars to specific scene

### DIFF
--- a/packages/phaser3-health-bar/src/demo/scene/demo-scene.js
+++ b/packages/phaser3-health-bar/src/demo/scene/demo-scene.js
@@ -45,8 +45,14 @@ export default class DemoScene extends Scene {
         worldX = x * 100 + OFFSET;
         worldY = y * 100 + OFFSET;
         sprite = new Phaser.GameObjects.Sprite(this, worldX, worldY, spriteKey);
-        this.physics.world.enable([ sprite ]);
-        sprite.body.setVelocity(-50, 100).setBounce(1, 1).setCollideWorldBounds(true);
+        this.physics.world.enable([sprite]);
+        sprite.health = 55;
+        sprite.maxHealth = 100;
+        sprite.minHealth = 0;
+        sprite.body
+          .setVelocity(-50, 100)
+          .setBounce(1, 1)
+          .setCollideWorldBounds(true);
 
         if (setAsInteractive) {
           sprite.setInteractive();
@@ -64,7 +70,7 @@ export default class DemoScene extends Scene {
 
     // Test on killing a sprite
     keyboard.on('keydown-R', () => {
-      const randomIndex = Phaser.Math.Between(0, mySprites.length -1);
+      const randomIndex = Phaser.Math.Between(0, mySprites.length - 1);
       const sprite = mySprites[randomIndex];
 
       if (sprite) {
@@ -72,10 +78,6 @@ export default class DemoScene extends Scene {
         this.mySprites = mySprites.filter(s => s !== sprite);
       }
     });
-  }
-
-  updateSprites() {
-
   }
 
   preload() {
@@ -91,18 +93,29 @@ export default class DemoScene extends Scene {
 
     this.healthBarPlugin = this.plugins.start('HealthBarPlugin', 'healthBarPlugin');
     this.healthBarPlugin.setup(this, {
+      barHeight: 15,
       backgroundColor: 0xff00ff,
+      camera: this.cameras.main,
       currentValueColor: 0x00ff00,
+      offsetY: 10,
       outlineColor: 0xffffff,
       outlineWidth: 2,
       // childSelector: (child) => child.input?.enabled,
-      propToWatch: 'health',
-      visibleOn: ['hover'],
+      propToWatch: {
+        current: 'health',
+        max: 'maxHealth',
+        min: 'minHealth',
+      },
+      visibleOnSelector: child => {
+        const { input } = this;
+        const { activePointer } = input;
+        // If pointer overlaps with child, or other conditions
+        return child.isSelected || child.input?.enabled;
+      },
     });
 
     this.fpsText = this.add.text(10, 10, '');
     this.fpsText.setScrollFactor(0);
-
   }
 
   update(time, delta) {

--- a/packages/phaser3-health-bar/src/js/lib/background-bar.js
+++ b/packages/phaser3-health-bar/src/js/lib/background-bar.js
@@ -1,0 +1,18 @@
+import PluginConfig from './plugin-config';
+import BarGraphics from './bar-graphic';
+
+export default class BackgroundBar extends BarGraphics {
+  drawAll() {
+    const backgroundColor = PluginConfig.get('backgroundColor');
+    const barHeight = PluginConfig.get('barHeight');
+    const outlineColor = PluginConfig.get('outlineColor');
+    const outlineWidth = PluginConfig.get('outlineWidth');
+
+    this.clear();
+    this.lineStyle(outlineWidth, outlineColor, 1);
+    this.fillStyle(backgroundColor, 1);
+    let TEMP_HEIGHT = 50;
+    this.fillRect(0, 0, TEMP_HEIGHT, barHeight);
+    this.strokeRect(0, 0, TEMP_HEIGHT, barHeight);
+  }
+}

--- a/packages/phaser3-health-bar/src/js/lib/bar-graphic.js
+++ b/packages/phaser3-health-bar/src/js/lib/bar-graphic.js
@@ -1,0 +1,35 @@
+import Phaser from 'phaser';
+import PluginConfig from './plugin-config';
+
+export default class BarGraphics extends Phaser.GameObjects.Graphics {
+  child;
+
+  constructor(scene, child) {
+    super(scene);
+    this.child = child;
+    this.drawAll();
+  }
+
+  drawAll() {}
+
+  preDestroy() {}
+
+  destroy(fromScene) {
+    super.destroy(fromScene);
+  }
+
+  update(time, delta) {
+    const { child } = this;
+    // const visibleOnSelector = PluginConfig.get('visibleOnSelector');
+    // const isVisible = visibleOnSelector(child);
+
+    const camera = PluginConfig.get('camera');
+    const offsetX = PluginConfig.get('offsetX');
+    const offsetY = PluginConfig.get('barHeight') + PluginConfig.get('offsetY');
+    const childBounds = child.getBounds();
+    const x = (childBounds.x - camera.worldView.x) * camera.zoom;
+    const y = (childBounds.y - camera.worldView.y) * camera.zoom;
+
+    this.setPosition(x - offsetX, y - offsetY);
+  }
+}

--- a/packages/phaser3-health-bar/src/js/lib/foreground-bar.js
+++ b/packages/phaser3-health-bar/src/js/lib/foreground-bar.js
@@ -1,0 +1,13 @@
+import PluginConfig from './plugin-config';
+import BarGraphics from './bar-graphic';
+
+export default class ForegroundBar extends BarGraphics {
+  drawAll() {
+    const barHeight = PluginConfig.get('barHeight');
+    const currentValueColor = PluginConfig.get('currentValueColor');
+
+    this.clear();
+    this.fillStyle(currentValueColor, 1);
+    this.fillRect(0, 0, 30, barHeight);
+  }
+}

--- a/packages/phaser3-health-bar/src/js/lib/health-bar-scene.js
+++ b/packages/phaser3-health-bar/src/js/lib/health-bar-scene.js
@@ -1,0 +1,37 @@
+import HealthBar from './health-bar';
+import PluginConfig from './plugin-config';
+
+export const SCENE_KEY = 'HealthBarPlugin:HealthBarScene';
+
+export default class HealthBarScene extends Phaser.Scene {
+  isDisabled = false;
+
+  plugin;
+  groups = new Set();
+  // mouseInterface;
+
+  constructor() {
+    super({ key: SCENE_KEY });
+  }
+
+  setPlugin(plugin) {
+    this.plugin = plugin;
+  }
+
+  addHealthBar(child) {
+    const healthBarGroup = new HealthBar(this, child);
+    child.healthBar = healthBarGroup;
+  }
+
+  disable() {
+    this.isDisabled = true;
+  }
+
+  enable() {
+    this.isDisabled = false;
+  }
+
+  update(time, delta) {
+    this.children.each(bar => bar.update(time, delta));
+  }
+}

--- a/packages/phaser3-health-bar/src/js/lib/health-bar.js
+++ b/packages/phaser3-health-bar/src/js/lib/health-bar.js
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 
-import PluginConfig from './plugin-config';
+import ForegroundBar from './foreground-bar';
+import BackgroundBar from './background-bar';
 
 export default class HealthBar extends Phaser.GameObjects.Group {
   background;
@@ -11,41 +12,11 @@ export default class HealthBar extends Phaser.GameObjects.Group {
     super(scene);
 
     this.child = child;
-    this.background = new Phaser.GameObjects.Graphics(scene);
-    this.foreground = new Phaser.GameObjects.Graphics(scene);
-    this.foreground.update = () => {
-      console.log('blah');
-    };
+    this.background = new BackgroundBar(scene, child);
+    this.foreground = new ForegroundBar(scene, child);
 
     this.add(this.background, true);
     this.add(this.foreground, true);
-
-    this.drawBackground();
-    this.drawForeground();
-  }
-
-  drawBackground() {
-    const { background, child } = this;
-    const { x, y } = child;
-    const backgroundColor = PluginConfig.get('backgroundColor');
-    const outlineColor = PluginConfig.get('outlineColor');
-    const outlineWidth = PluginConfig.get('outlineWidth');
-
-    background.clear();
-    background.lineStyle(outlineWidth, outlineColor, 1);
-    background.fillStyle(backgroundColor, 1);
-    background.fillRect(x, y, 50, 20);
-    background.strokeRect(x, y, 50, 20);
-  }
-
-  drawForeground() {
-    const { foreground, child } = this;
-    const { x, y } = child;
-    const currentValueColor = PluginConfig.get('currentValueColor');
-
-    foreground.clear();
-    foreground.fillStyle(currentValueColor, 1);
-    foreground.fillRect(x, y, 30, 20);
   }
 
   hide() {

--- a/packages/phaser3-health-bar/src/js/lib/plugin-config.js
+++ b/packages/phaser3-health-bar/src/js/lib/plugin-config.js
@@ -3,9 +3,24 @@ import Phaser from 'phaser';
 const NOOP = () => {};
 
 export const IS_SPRITE = child => child instanceof Phaser.GameObjects.Sprite;
+export const IS_SELECTED = child => child.isEnabled;
 
 export const PLUGIN_DEFAULT_CONFIG = {
+  camera: null,
   childSelector: IS_SPRITE,
+  backgroundColor: 0x000000,
+  barHeight: 15,
+  currentValueColor: 0x33ff33,
+  offsetX: 0,
+  offsetY: 10,
+  outlineColor: 0xffffff,
+  outlineWidth: 2,
+  propToWatch: {
+    current: 'health',
+    max: 'maxHealth',
+    min: 'minHealth',
+  },
+  visibleOnSelector: IS_SELECTED,
 };
 
 class PluginConfig {


### PR DESCRIPTION
- Renders the health bars to their own scene, to avoid issues with camera zoom
- Should do garbage collection if the attach child is destroyed, or scene changes.