### PR TITLE
GH-37 Add optional rotation to gameObject onMove

### DIFF
--- a/packages/phaser3-game-object-engine/src/demo/scene/demo-scene.js
+++ b/packages/phaser3-game-object-engine/src/demo/scene/demo-scene.js
@@ -109,7 +109,7 @@ export default class DemoScene extends Scene {
     let sprite, y, worldX, worldY;
     this.mySprites = [];
     let x = 1;
-    const length = 1;
+    const length = 2;
     const OFFSET = 200;
 
     for (x; x <= length; x += 1) {
@@ -122,8 +122,6 @@ export default class DemoScene extends Scene {
         this.mySprites.push(sprite);
       }
     }
-
-    this.physics.world.enable(this.mySprites);
   }
 
   createAutoMovingSprite() {

--- a/packages/phaser3-game-object-engine/src/demo/sprite/demo-sprite.js
+++ b/packages/phaser3-game-object-engine/src/demo/sprite/demo-sprite.js
@@ -9,10 +9,13 @@ export default class DemoSprite extends Phaser.GameObjects.Sprite {
     this.id = v4();
 
     scene.gameObjectEnginePlugin.addEngineToGameObject(this, {
+      rotateOnMove: false,
+      rotateSpeed: 10,
       speed: TEMP_SPEED,
       gameObjectStoppingDistance: 128,
     });
     scene.add.existing(this);
+    scene.physics.world.enable(this);
     this.setInteractive();
   }
 }


### PR DESCRIPTION
- Adds an opt-in config value to rotate the `GameObject` as it moves towards the way points
- Closes #37 