### PR TITLE
Utility method to find closest poly to world-point

### DIFF
--- a/packages/phaser3-navmesh-generation/src/demo/index.html
+++ b/packages/phaser3-navmesh-generation/src/demo/index.html
@@ -1,17 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>Phaser NavMesh Generation</title>
-</head>
-<body>
+  </head>
+  <body>
     <div id="game_canvas"></div>
     <p>
-        <strong>Left click</strong> to draw random colliding tile to map;
-        <strong>Right click</strong> to move sprites to that point on map;
-        <strong>'P'</strong> to pause;
-        <strong>'S'</strong> to toggle the 'sprite' dropper;
-        <strong>'K'</strong> to remove the last 'sprite' and refresh
+      <strong>Shift + Left click</strong> to draw random colliding tile to map; <strong>Left click</strong> to check the nav-mesh poly underneath pointer (see
+      console) <strong>Right click</strong> to move sprites to that point on map; <strong>'P'</strong> to pause; <strong>'S'</strong> to toggle the 'sprite'
+      dropper; <strong>'K'</strong> to remove the last 'sprite' and refresh
     </p>
-</body>
+  </body>
 </html>

--- a/packages/phaser3-navmesh-generation/src/js/lib/navMesh.js
+++ b/packages/phaser3-navmesh-generation/src/js/lib/navMesh.js
@@ -69,4 +69,38 @@ export default class NavMesh {
     return this.delaunay.polygons.find(polygon => polygon.contains(x, y));
   }
 
+  /**
+   * @method findClosestPolygonToPoint
+   * @description Finds the closest NavMesh polygon to the given world point
+   * @param point
+   * @param point.x {Number}
+   * @param point.y {Number}
+   */
+  findClosestPolygonToPoint(point) {
+    const { polygons } = this.delaunay;
+    let length = polygons.length;
+    let poly;
+    let distanceToLine;
+    let distance = Number.MAX_SAFE_INTEGER;
+    let closest;
+    let i = 0;
+    let edgesLength;
+    let j;
+
+    for (i; i < length; i += 1) {
+      poly = polygons[i];
+      j = 0;
+      edgesLength = poly.edges.length;
+
+      for (j; j < edgesLength; j += 1) {
+        distanceToLine = poly.edges[j].distanceToPoint(point);
+        if (distanceToLine < distance) {
+          distance = distanceToLine;
+          closest = poly;
+        }
+      }
+    }
+
+    return closest;
+  }
 }

--- a/packages/phaser3-navmesh-generation/src/js/lib/utils/line.js
+++ b/packages/phaser3-navmesh-generation/src/js/lib/utils/line.js
@@ -1,11 +1,30 @@
 import Phaser from 'phaser';
 
+function sqr(x) {
+  return x * x;
+}
+function dist2(start, end) {
+  return sqr(start.x - end.x) + sqr(start.y - end.y);
+}
+
+function distToSegmentSquared(point, start, end) {
+  const l2 = dist2(start, end);
+  if (l2 === 0) {
+    return dist2(point, start);
+  }
+
+  let t = ((point.x - start.x) * (end.x - start.x) + (point.y - start.y) * (end.y - start.y)) / l2;
+  t = Math.max(0, Math.min(1, t));
+
+  return dist2(point, { x: start.x + t * (end.x - start.x), y: start.y + t * (end.y - start.y) });
+}
+
 /**
  * @TODO instancing new Vectors each time the getter is invoked isn't great. Fix this later
  */
 export default class Line extends Phaser.Geom.Line {
   static RotateAroundPointByAngle(line, point, angle) {
-    const rotated = Phaser.Geom.Line.RotateAroundPoint(line, point, (angle / 2));
+    const rotated = Phaser.Geom.Line.RotateAroundPoint(line, point, angle / 2);
     return new Line(rotated.x1, rotated.y1, rotated.x2, rotated.y2);
   }
 
@@ -19,5 +38,9 @@ export default class Line extends Phaser.Geom.Line {
 
   get end() {
     return new Phaser.Math.Vector2(this.x2, this.y2);
+  }
+
+  distanceToPoint(point) {
+    return Math.sqrt(distToSegmentSquared(point, this.start, this.end));
   }
 }

--- a/packages/phaser3-navmesh-generation/src/js/nav-mesh-plugin.js
+++ b/packages/phaser3-navmesh-generation/src/js/nav-mesh-plugin.js
@@ -9,6 +9,10 @@ function err() {
 }
 
 export default class NavMeshPlugin extends Phaser.Plugins.BasePlugin {
+  /**
+   * @name navMesh
+   * @type NavMesh
+   */
   navMesh;
   spritesCache = new SpritesCache();
 
@@ -33,6 +37,30 @@ export default class NavMeshPlugin extends Phaser.Plugins.BasePlugin {
     return this.navMesh;
   }
 
+  /**
+   * @method getClosestPolygon
+   * @description Finds the closest NavMesh polygon, based on world point
+   * @param position The world point
+   * @param position.x {Number}
+   * @param position.y {Number}
+   * @param includeOutOfBounds {Boolean} whether to include "out of bounds" searches
+   */
+  getClosestPolygon(position, includeOutOfBounds = false) {
+    if (!this.navMesh) {
+      return false;
+    } else if (!position || !position.x || !position.y) {
+      return false;
+    }
+
+    const poly = this.navMesh.getPolygonByXY(position.x, position.y);
+    if (!includeOutOfBounds) {
+      return poly || false;
+    }
+
+    // If no poly (ie, out of bounds), try finding the closest polygon in the whole nav-mesh
+    return poly || this.navMesh.findClosestPolygonToPoint(position) || false;
+  }
+
   getPath(startPosition, endPosition, offset) {
     if (!this.navMesh) {
       return false;
@@ -49,9 +77,7 @@ export default class NavMeshPlugin extends Phaser.Plugins.BasePlugin {
   getAllTilesWithin(worldX, worldY, spriteWidth, spriteHeight) {
     const tileLayer = Config.get('tileLayer');
     const tileAtXY = tileLayer.getTileAtWorldXY(worldX, worldY, true);
-    console.log('tileAtXY', tileAtXY);
     if (!tileAtXY) {
-      console.groupEnd();
       return [];
     }
 
@@ -83,7 +109,7 @@ export default class NavMeshPlugin extends Phaser.Plugins.BasePlugin {
     }
 
     const tilesWithin = this.getAllTilesWithin(worldX, worldY, spriteWidth, spriteHeight);
-    forEach(tilesWithin, (tile) => {
+    forEach(tilesWithin, tile => {
       const isAlreadyCached = this.spritesCache.has(tile);
       if (isAlreadyCached) {
         return;
@@ -99,7 +125,7 @@ export default class NavMeshPlugin extends Phaser.Plugins.BasePlugin {
       tile.setCollision(true, true, true, true, true);
     });
 
-    if(tilesWithin.length) {
+    if (tilesWithin.length) {
       this.navMesh.generate();
     }
   }
@@ -116,7 +142,7 @@ export default class NavMeshPlugin extends Phaser.Plugins.BasePlugin {
     }
 
     const tilesWithin = this.getAllTilesWithin(worldX, worldY, spriteWidth, spriteHeight);
-    forEach(tilesWithin, (tile) => {
+    forEach(tilesWithin, tile => {
       const cachedTileIndex = this.spritesCache.get(tile);
       if (cachedTileIndex) {
         tileLayer.putTileAt(cachedTileIndex, tile.x, tile.y);
@@ -130,7 +156,7 @@ export default class NavMeshPlugin extends Phaser.Plugins.BasePlugin {
   }
 
   start() {
-    console.log('start')
+    console.log('start');
   }
 
   stop() {

--- a/packages/phaser3-navmesh-generation/webpack/base.js
+++ b/packages/phaser3-navmesh-generation/webpack/base.js
@@ -9,9 +9,7 @@ const config = require('./config');
 module.exports = {
   mode: 'development',
   devtool: 'eval-source-map',
-  entry: {
-    entry: `${config.DEMO}/index.js`
-  },
+  entry: `${config.DEMO}/index.js`,
   resolve: {
     alias: {
       src: config.SRC,
@@ -25,7 +23,7 @@ module.exports = {
         use: {
           loader: 'babel-loader',
           options: config.BABEL,
-        }
+        },
       },
       {
         test: [/\.vert$/, /\.frag$/],


### PR DESCRIPTION
- A utility method to find the closest NavMesh polygon, given any world point. If no poly found, we can optionally search to find the closest (ie, if the world-point is outside the navmesh itself somehow; useful to get an Actor back onto the navmesh for instance)